### PR TITLE
取消强制路径配置

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ module.exports = class QiniuPlugin {
       let assets = compilation.assets;
       let hash = compilation.hash;
       let uploadPath = this.options.path || '[hash]';
+      if (this.options.path === '/'){
+         uploadPath = "";
+      }
       let exclude = isRegExp(this.options.exclude) && this.options.exclude;
       let include = isRegExp(this.options.include) && this.options.include;
       let batch = this.options.batch || 20;


### PR DESCRIPTION
path配置为 “/” 时期望放到 七牛的根目录下
但是七牛对于 “/”不可忽略。
http://a.a.a/index.html  和 http://a.a.a//index.html  为不同。